### PR TITLE
OC-11112 Handle Fog errors in knife-plugin

### DIFF
--- a/lib/chef/knife/cloud/fog/service.rb
+++ b/lib/chef/knife/cloud/fog/service.rb
@@ -58,8 +58,6 @@ class Chef
               ui.fatal(message)
             end
             raise CloudExceptions::ServerCreateError, message
-          rescue Fog::Errors::Error => e
-            raise CloudExceptions::ServerCreateError, e.message
           end
 
           print "\n#{ui.color("Waiting for server [wait time = #{options[:server_create_timeout]}]", :magenta)}"


### PR DESCRIPTION
PBI ref: https://tickets.corp.opscode.com/browse/OC-11112
Remove error handling from knife-cloud, handle it in knife-plugin.

^@adamedx, @kaustubh-d 
