### PR TITLE
[knife-cloud] Common short options in ssh & winrm (SSH override winrm config)

### DIFF
--- a/lib/chef/knife/cloud/server/create_command.rb
+++ b/lib/chef/knife/cloud/server/create_command.rb
@@ -111,28 +111,7 @@ class Chef
 
         # any cloud specific initializations/cleanup we want to do around bootstrap.
         def before_bootstrap
-          #Here, ssh config override winrm config
-
-          # unchanged ssh_user and changed winrm_user, override ssh_user
-          if locate_config_value(:ssh_user).eql?(options[:ssh_user][:default]) &&
-              !locate_config_value(:winrm_user).eql?(options[:winrm_user][:default])
-            config[:ssh_user] = locate_config_value(:winrm_user)
-          end
-          # unchanged ssh_port and changed winrm_port, override ssh_port
-          if locate_config_value(:ssh_port).nil? &&
-              !locate_config_value(:winrm_port).eql?(options[:winrm_port][:default])
-            config[:ssh_port] = locate_config_value(:winrm_port)
-          end
-          # unset ssh_password and set winrm_password, override ssh_password
-          if locate_config_value(:ssh_password).nil? &&
-              !locate_config_value(:winrm_password).nil?
-            config[:ssh_password] = locate_config_value(:winrm_password)
-          end
-          # unset identity_file and set kerberos_keytab_file, override identity_file
-          if locate_config_value(:identity_file).nil? &&
-              !locate_config_value(:kerberos_keytab_file).nil?
-            config[:identity_file] = locate_config_value(:kerberos_keytab_file)
-          end
+          ssh_override_winrm if locate_config_value(:bootstrap_protocol) == 'ssh'
         end
 
         def after_bootstrap
@@ -152,6 +131,32 @@ class Chef
         end
 
         def post_connection_validations
+        end
+
+        private
+
+        # Here, ssh config override winrm config
+        def ssh_override_winrm
+          # unchanged ssh_user and changed winrm_user, override ssh_user
+          if locate_config_value(:ssh_user).eql?(options[:ssh_user][:default]) &&
+              !locate_config_value(:winrm_user).eql?(options[:winrm_user][:default])
+            config[:ssh_user] = locate_config_value(:winrm_user)
+          end
+          # unchanged ssh_port and changed winrm_port, override ssh_port
+          if locate_config_value(:ssh_port).nil? &&
+              !locate_config_value(:winrm_port).eql?(options[:winrm_port][:default])
+            config[:ssh_port] = locate_config_value(:winrm_port)
+          end
+          # unset ssh_password and set winrm_password, override ssh_password
+          if locate_config_value(:ssh_password).nil? &&
+              !locate_config_value(:winrm_password).nil?
+            config[:ssh_password] = locate_config_value(:winrm_password)
+          end
+          # unset identity_file and set kerberos_keytab_file, override identity_file
+          if locate_config_value(:identity_file).nil? &&
+              !locate_config_value(:kerberos_keytab_file).nil?
+            config[:identity_file] = locate_config_value(:kerberos_keytab_file)
+          end          
         end
       end # class ServerCreateCommand
     end

--- a/spec/unit/server_create_command_spec.rb
+++ b/spec/unit/server_create_command_spec.rb
@@ -142,45 +142,57 @@ describe Chef::Knife::Cloud::ServerCreateCommand do
   describe "#before_bootstrap" do
 
     before(:all) { @instance = ServerCreate.new }
-    
-    it "set ssh_user value by using -x option for ssh bootstrap protocol or linux image" do
-      # Currently -x option set config[:winrm_user]
-      # default value of config[:ssh_user] is root
-      @instance.config[:winrm_user] = "ubuntu"
-      @instance.config[:ssh_user] = "root"
 
-      @instance.before_bootstrap
-      expect(@instance.config[:ssh_user]).to eq("ubuntu")
+    context "bootstrap_protocol shh" do
+      before {@instance.config[:bootstrap_protocol] = "ssh"}
+      
+      it "set ssh_user value by using -x option for ssh bootstrap protocol or linux image" do
+        # Currently -x option set config[:winrm_user]
+        # default value of config[:ssh_user] is root
+        @instance.config[:winrm_user] = "ubuntu"
+        @instance.config[:ssh_user] = "root"
+
+        @instance.before_bootstrap
+        expect(@instance.config[:ssh_user]).to eq("ubuntu")
+      end
+
+      it "set ssh_password value by using -P option for ssh bootstrap protocol or linux image" do
+        # Currently -P option set config[:winrm_password]
+        # default value of config[:ssh_password] is nil
+        @instance.config[:winrm_password] = "winrm_password"
+        @instance.config[:ssh_password] = nil
+
+        @instance.before_bootstrap
+        expect(@instance.config[:ssh_password]).to eq("winrm_password")
+      end
+
+      it "set ssh_port value by using -p option for ssh bootstrap protocol or linux image" do
+        # Currently -p option set config[:winrm_port]
+        # default value of config[:ssh_port] is nil
+        @instance.config[:winrm_port] = "1234"
+        @instance.config[:ssh_port] =  nil
+
+        @instance.before_bootstrap
+        expect(@instance.config[:ssh_port]).to eq("1234")
+      end
+
+      it "set identity_file value by using -i option for ssh bootstrap protocol or linux image" do
+        # Currently -i option set config[:kerberos_keytab_file]
+        # default value of config[:identity_file] is nil
+        @instance.config[:kerberos_keytab_file] = "kerberos_keytab_file"
+        @instance.config[:identity_file] = nil
+
+        @instance.before_bootstrap
+        expect(@instance.config[:identity_file]).to eq("kerberos_keytab_file")
+      end
     end
 
-    it "set ssh_password value by using -P option for ssh bootstrap protocol or linux image" do
-      # Currently -P option set config[:winrm_password]
-      # default value of config[:ssh_password] is nil
-      @instance.config[:winrm_password] = "winrm_password"
-      @instance.config[:ssh_password] = nil
-
-      @instance.before_bootstrap
-      expect(@instance.config[:ssh_password]).to eq("winrm_password")
-    end
-
-    it "set ssh_port value by using -p option for ssh bootstrap protocol or linux image" do
-      # Currently -p option set config[:winrm_port]
-      # default value of config[:ssh_port] is nil
-      @instance.config[:winrm_port] = "1234"
-      @instance.config[:ssh_port] =  nil
-
-      @instance.before_bootstrap
-      expect(@instance.config[:ssh_port]).to eq("1234")
-    end
-
-    it "set identity_file value by using -i option for ssh bootstrap protocol or linux image" do
-      # Currently -i option set config[:kerberos_keytab_file]
-      # default value of config[:identity_file] is nil
-      @instance.config[:kerberos_keytab_file] = "kerberos_keytab_file"
-      @instance.config[:identity_file] = nil
-
-      @instance.before_bootstrap
-      expect(@instance.config[:identity_file]).to eq("kerberos_keytab_file")
+    context "bootstrap_protocol winrm" do
+      it "skip ssh_override_winrm" do
+        @instance.config[:bootstrap_protocol] = "winrm"
+        expect(@instance).to_not receive(:ssh_override_winrm)
+        @instance.before_bootstrap
+      end
     end
   end
 end


### PR DESCRIPTION
@muktaa 
I've added changes to set ssh config -x,-p,-P,-i  short options by overriding winrm short options -x(winrm-user) -p(winrm-port) -P(winrm-password) and -i(kerberos_keytab_file) respectively. 
