### PR TITLE
Limit hostnames to 15 characters (for windows)

### DIFF
--- a/lib/chef/knife/cloud/server/create_command.rb
+++ b/lib/chef/knife/cloud/server/create_command.rb
@@ -126,8 +126,8 @@ class Chef
         #generate a random name if chef_node_name is empty
         def get_node_name(chef_node_name, prefix)
           return chef_node_name unless chef_node_name.nil?
-          #lazy uuids
-          chef_node_name = "#{prefix}-"+rand.to_s.split('.')[1]
+          #lazy uuids, 15 chars cause windows has limits
+          chef_node_name = ("#{prefix}-"+rand.to_s.split('.')[1]).slice(0,14)
         end
 
         def post_connection_validations


### PR DESCRIPTION
When trying to use knife-cloud based plugins, the default node name generation is more than 15 characters which gives windows boxes a hard time. This patch limits the names to 15 characters.
/cc @mattray @taylor @vulk
