### PR TITLE
Add options for new vault bootstrap support

### DIFF
--- a/lib/chef/knife/cloud/chefbootstrap/bootstrap_options.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/bootstrap_options.rb
@@ -179,6 +179,25 @@ class Chef
               :description => "Add options to curl when install chef-client",
               :proc        => Proc.new { |co| Chef::Config[:knife][:bootstrap_curl_options] = co }
 
+            option :bootstrap_vault_file,
+              :long        => '--bootstrap-vault-file VAULT_FILE',
+              :description => 'A JSON file with a list of vault(s) and item(s) to be updated'
+
+            option :bootstrap_vault_json,
+              :long        => '--bootstrap-vault-json VAULT_JSON',
+              :description => 'A JSON string with the vault(s) and item(s) to be updated'
+
+            option :bootstrap_vault_item,
+              :long        => '--bootstrap-vault-item VAULT_ITEM',
+              :description => 'A single vault and item to update as "vault:item"',
+              :proc        => Proc.new { |i|
+                (vault, item) = i.split(/:/)
+                Chef::Config[:knife][:bootstrap_vault_item] ||= {}
+                Chef::Config[:knife][:bootstrap_vault_item][vault] ||= []
+                Chef::Config[:knife][:bootstrap_vault_item][vault].push(item)
+                Chef::Config[:knife][:bootstrap_vault_item]
+              }
+
             option :auth_timeout,
               :long => "--auth-timeout MINUTES",
               :description => "The maximum time in minutes to wait to for authentication over the transport to the node to succeed. The default value is 25 minutes.",

--- a/lib/chef/knife/cloud/chefbootstrap/bootstrap_protocol.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/bootstrap_protocol.rb
@@ -61,6 +61,9 @@ class Chef
           bootstrap.config[:secret] = locate_config_value(:secret)
           bootstrap.config[:secret_file] = locate_config_value(:secret_file)
           bootstrap.config[:template_file] =  locate_config_value(:template_file)
+          bootstrap.config[:bootstrap_vault_file] = locate_config_value(:bootstrap_vault_file)
+          bootstrap.config[:bootstrap_vault_json] = locate_config_value(:bootstrap_vault_json)
+          bootstrap.config[:bootstrap_vault_item] =  locate_config_value(:bootstrap_vault_item)
         end
 
       end

--- a/spec/unit/bootstrap_protocol_spec.rb
+++ b/spec/unit/bootstrap_protocol_spec.rb
@@ -55,6 +55,9 @@ describe Chef::Knife::Cloud::BootstrapProtocol do
       @config[:secret] = "secret"
       @config[:secret_file] = "secret_file"
       @config[:template_file] = "../template_file"
+      @config[:bootstrap_vault_file] = "/foo/bar/baz"
+      @config[:bootstrap_vault_json] = '{ "vault": "item1" }'
+      @config[:bootstrap_vault_item] = { 'vault' => 'item1' }
       allow(@config).to receive(:locate_config_value).and_return({})
       @instance.bootstrap = Chef::Knife::Bootstrap.new
       @instance.init_bootstrap_options
@@ -65,6 +68,9 @@ describe Chef::Knife::Cloud::BootstrapProtocol do
       expect(@instance.bootstrap.config[:secret]).to eq(@config[:secret])
       expect(@instance.bootstrap.config[:secret_file]).to eq(@config[:secret_file])
       expect(@instance.bootstrap.config[:template_file]).to eq(@config[:template_file])
+      expect(@instance.bootstrap.config[:bootstrap_vault_file]).to eq(@config[:bootstrap_vault_file])
+      expect(@instance.bootstrap.config[:bootstrap_vault_json]).to eq(@config[:bootstrap_vault_json])
+      expect(@instance.bootstrap.config[:bootstrap_vault_item]).to eq(@config[:bootstrap_vault_item])
     end
   end
 end


### PR DESCRIPTION
This is a pretty simple patch to add the new `bootstrap_vault_*` options to knife-cloud.

This has implications when using things like `knife openstack` - due to the fact that `chef/knife/bootstrap` options aren't exposed, they need to be checked and loaded manually, although all the functionality of the module exists otherwise. Seeing this and looking at the already added options, this seemed like a pretty logical and straightforward addition.

I have not tested this 100% extensively - I am currently testing using the `bootstrap_vault_item` option directly from `knife.rb`, but that will probably change soon. Mind you, the options have been directly copied from `bootstrap.rb` in knife, so hopefully there is not too much to break.