### PR TITLE
Show result in the format provided by user in -F or --format option

### DIFF
--- a/lib/chef/knife/cloud/list_resource_command.rb
+++ b/lib/chef/knife/cloud/list_resource_command.rb
@@ -53,7 +53,7 @@ class Chef
           end
           false
         end
-        
+
         # Derived class can override this to add more functionality.
         def get_resource_col_val(resource)
           resource_filtered = false
@@ -70,24 +70,29 @@ class Chef
 
         # When @columns_with_info is nil display all
         def list(resources)
-          # display column wise only if @columns_with_info is specified, else as a json for readable display.
-          begin
-            resource_list = @columns_with_info.map { |col_info| ui.color(col_info[:label], :bold) } if @columns_with_info.length > 0
-            resources.sort_by{|x| x.send(@sort_by_field).downcase }.each do |resource|
-              if @columns_with_info.length > 0
-                list = get_resource_col_val(resource)
-                resource_list.concat(list) unless list.nil?
-              else
-                puts resource.to_json
-                puts "\n"
+          if(config[:format] == "summary")
+            # display column wise only if @columns_with_info is specified, else as a json for readable display.
+            begin
+              resource_list = @columns_with_info.map { |col_info| ui.color(col_info[:label], :bold) } if @columns_with_info.length > 0
+              resources.sort_by{|x| x.send(@sort_by_field).downcase }.each do |resource|
+                if @columns_with_info.length > 0
+                  list = get_resource_col_val(resource)
+                  resource_list.concat(list) unless list.nil?
+                else
+                  puts resource.to_json
+                  puts "\n"
+                end
               end
+
+            rescue => e
+              ui.fatal("Unknown resource error : #{e.message}")
+              raise e
             end
 
-          rescue => e
-            ui.fatal("Unknown resource error : #{e.message}")
-            raise e
+            puts ui.list(resource_list, :uneven_columns_across, @columns_with_info.length) if @columns_with_info.length > 0
+          else
+            output(format_for_display(resources))
           end
-          puts ui.list(resource_list, :uneven_columns_across, @columns_with_info.length) if @columns_with_info.length > 0
         end
 
       end # class ResourceListCommand

--- a/spec/unit/list_resource_command_spec.rb
+++ b/spec/unit/list_resource_command_spec.rb
@@ -24,7 +24,7 @@ require 'excon/errors'
 
 describe Chef::Knife::Cloud::ResourceListCommand do
   it_behaves_like Chef::Knife::Cloud::Command, Chef::Knife::Cloud::ResourceListCommand.new
-  
+
   let (:instance) {Chef::Knife::Cloud::ResourceListCommand.new}
   let (:resources) {[ TestResource.new({:id => "resource-1", :os => "ubuntu"}),
                    TestResource.new({:id => "resource-2", :os => "windows"})]}
@@ -44,6 +44,7 @@ describe Chef::Knife::Cloud::ResourceListCommand do
       let(:test_resource) { "test" }
       before(:each) do
         expect(instance.ui).to receive(:fatal)
+        instance.config[:format] = "summary"
       end
 
       it "handle generic exception" do
@@ -63,6 +64,7 @@ describe Chef::Knife::Cloud::ResourceListCommand do
       allow(instance).to receive(:query_resource).and_return(resources)
       allow(instance).to receive(:create_service_instance).and_return(Chef::Knife::Cloud::Service.new)
       allow(instance).to receive(:puts)
+      instance.config[:format] = "summary"
     end
 
     it "lists resources in json format when columns_with_info parameter is empty" do
@@ -88,6 +90,7 @@ describe Chef::Knife::Cloud::ResourceListCommand do
         allow(@derived_instance).to receive(:query_resource).and_return(resources)
         allow(@derived_instance).to receive(:puts)
         allow(@derived_instance).to receive(:create_service_instance).and_return(Chef::Knife::Cloud::Service.new)
+        @derived_instance.config[:format] = "summary"
       end
 
       it "lists all resources" do
@@ -125,6 +128,7 @@ describe Chef::Knife::Cloud::ResourceListCommand do
         allow(@derived_instance).to receive(:query_resource).and_return(resources)
         allow(@derived_instance).to receive(:puts)
         allow(@derived_instance).to receive(:create_service_instance).and_return(Chef::Knife::Cloud::Service.new)
+        @derived_instance.config[:format] = "summary"
       end
 
       it "lists formatted list of resources" do


### PR DESCRIPTION
W.R.T. https://github.com/chef/knife-cloud/issues/91. This fixes --format option for some of the `knife openstack` commands like `flavor list`, `image list` and `server list` 