### PR TITLE
Passing bootstrap_ip_address as an array object instead of string

### DIFF
--- a/lib/chef/knife/cloud/chefbootstrap/bootstrap_protocol.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/bootstrap_protocol.rb
@@ -46,7 +46,7 @@ class Chef
 
         def init_bootstrap_options
           # set the command bootstrap options.
-          bootstrap.name_args = locate_config_value(:bootstrap_ip_address)
+          bootstrap.name_args << locate_config_value(:bootstrap_ip_address)
           bootstrap.config[:chef_node_name] = locate_config_value(:chef_node_name)
           bootstrap.config[:run_list] = locate_config_value(:run_list)
           bootstrap.config[:prerelease] = locate_config_value(:prerelease)

--- a/spec/unit/bootstrap_protocol_spec.rb
+++ b/spec/unit/bootstrap_protocol_spec.rb
@@ -72,7 +72,7 @@ describe Chef::Knife::Cloud::BootstrapProtocol do
       allow(@config).to receive(:locate_config_value).and_return({})
       @instance.bootstrap = Chef::Knife::Bootstrap.new
       @instance.init_bootstrap_options
-      expect(@instance.bootstrap.name_args).to eq(@config[:bootstrap_ip_address])
+      expect(@instance.bootstrap.name_args).to eq([@config[:bootstrap_ip_address]])
       expect(@instance.bootstrap.config[:chef_node_name]).to eq(@config[:chef_node_name])
       expect(@instance.bootstrap.config[:environment]).to eq(@config[:environment])
       expect(@instance.bootstrap.config[:first_boot_attributes]).to eq(@config[:first_boot_attributes])

--- a/spec/unit/ssh_bootstrap_protocol_spec.rb
+++ b/spec/unit/ssh_bootstrap_protocol_spec.rb
@@ -65,7 +65,7 @@ describe Chef::Knife::Cloud::SshBootstrapProtocol do
       allow(@config).to receive(:locate_config_value).and_return({})
       @instance.bootstrap = Chef::Knife::Bootstrap.new
       @instance.init_bootstrap_options
-      expect(@instance.bootstrap.name_args).to eq(@config[:bootstrap_ip_address])
+      expect(@instance.bootstrap.name_args).to eq([@config[:bootstrap_ip_address]])
       expect(@instance.bootstrap.config[:chef_node_name]).to eq(@config[:chef_node_name])
       expect(@instance.bootstrap.config[:environment]).to eq(@config[:environment])
       expect(@instance.bootstrap.config[:ssh_user]).to eq(@config[:ssh_user])

--- a/spec/unit/winrm_bootstrap_protocol_spec.rb
+++ b/spec/unit/winrm_bootstrap_protocol_spec.rb
@@ -58,7 +58,7 @@ describe Chef::Knife::Cloud::WinrmBootstrapProtocol do
       @config[:winrm_ssl_verify_mode] = "verify_none"
       @instance.bootstrap = Chef::Knife::Bootstrap.new
       @instance.init_bootstrap_options
-      expect(@instance.bootstrap.name_args).to eq(@config[:bootstrap_ip_address])
+      expect(@instance.bootstrap.name_args).to eq([@config[:bootstrap_ip_address]])
       expect(@instance.bootstrap.config[:chef_node_name]).to eq(@config[:chef_node_name])
       expect(@instance.bootstrap.config[:environment]).to eq(@config[:environment])
       expect(@instance.bootstrap.config[:winrm_user]).to eq(@config[:winrm_user])


### PR DESCRIPTION
Fix for https://github.com/chef/knife-openstack/issues/186 and https://github.com/chef/knife-cloud/issues/100

The issue was that `knife-windows` and `chef` are expecting `bootstrap_ip_address` to be provided as an array which they try to split here https://github.com/chef/knife-windows/blob/master/lib/chef/knife/winrm_knife_base.rb#L69. 
This was being passed as a String earlier, hence taking only the first character of the IP address.