### PR TITLE
Require Ruby 2.2.2 and bump all depedencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+language: ruby
+cache: bundler
+sudo: false
+
 rvm:
-  - 2.0.0
+  - 2.2.5
+  - 2.3.1
 
 gemfile: ci.gemfile
-
 script: bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ gemspec
 
 group :development do
   gem 'rake'
-  gem 'knife-windows'
 end

--- a/ci.gemfile
+++ b/ci.gemfile
@@ -5,14 +5,10 @@ gemspec
 
 if ENV['CHEF_VERSION'] == 'master'
   gem 'chef', github: 'chef/chef'
-elsif ENV['CHEF_VERSION'] == '< 12'
-  gem 'ohai', '7.4.1'
-  gem 'chef', ENV['CHEF_VERSION']
 else
   gem 'chef', ENV['CHEF_VERSION']
 end
 
 group :development do
   gem 'rake'
-  gem 'knife-windows'
 end

--- a/knife-cloud.gemspec
+++ b/knife-cloud.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'knife-windows', '>= 1.0'
   s.add_dependency 'chef',  '>= 12.0'
   s.add_dependency 'mixlib-shellout'
+  s.add_dependency 'excon', '>=  0.50' # excon 0.50 renamed the errors class and required updating rescues
 
   %w(rspec-core rspec-expectations rspec-mocks rspec_junit_formatter fog chefstyle).each { |gem| s.add_development_dependency gem }
 end

--- a/knife-cloud.gemspec
+++ b/knife-cloud.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = %w(lib spec)
+  s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency 'knife-windows', '>= 0.5.14'
-  s.add_dependency 'chef', '>= 0.10.10'
+  s.add_dependency 'knife-windows', '>= 1.0'
+  s.add_dependency 'chef',  '>= 12.0'
   s.add_dependency 'mixlib-shellout'
 
-  %w(rspec-core rspec-expectations rspec-mocks rspec_junit_formatter fog rubocop).each { |gem| s.add_development_dependency gem }
+  %w(rspec-core rspec-expectations rspec-mocks rspec_junit_formatter fog chefstyle).each { |gem| s.add_development_dependency gem }
 end

--- a/lib/chef/knife/cloud/fog/service.rb
+++ b/lib/chef/knife/cloud/fog/service.rb
@@ -33,11 +33,11 @@ class Chef
           add_api_endpoint
           @connection ||= begin
             connection  = Fog::Compute.new(@auth_params)
-                          rescue Excon::Errors::Unauthorized => e
+                          rescue Excon::Error::Unauthorized => e
                             error_message = "Connection failure, please check your username and password."
                             ui.fatal(error_message)
                             raise CloudExceptions::ServiceConnectionError, "#{e.message}. #{error_message}"
-                          rescue Excon::Errors::SocketError => e
+                          rescue Excon::Error::SocketError => e
                             error_message = "Connection failure, please check your authentication URL."
                             ui.fatal(error_message)
                             raise CloudExceptions::ServiceConnectionError, "#{e.message}. #{error_message}"
@@ -47,11 +47,11 @@ class Chef
         def network
           @network ||= begin
             network = Fog::Network.new(@auth_params)
-                      rescue Excon::Errors::Unauthorized => e
+                      rescue Excon::Error::Unauthorized => e
                         error_message = "Connection failure, please check your username and password."
                         ui.fatal(error_message)
                         raise CloudExceptions::ServiceConnectionError, "#{e.message}. #{error_message}"
-                      rescue Excon::Errors::SocketError => e
+                      rescue Excon::Error::SocketError => e
                         error_message = "Connection failure, please check your authentication URL."
                         ui.fatal(error_message)
                         raise CloudExceptions::ServiceConnectionError, "#{e.message}. #{error_message}"
@@ -67,7 +67,7 @@ class Chef
           begin
             add_custom_attributes(options[:server_def])
             server = connection.servers.create(options[:server_def])
-          rescue Excon::Errors::BadRequest => e
+          rescue Excon::Error::BadRequest => e
             response = Chef::JSONCompat.from_json(e.response.body)
             if response['badRequest']['code'] == 400
               message = "Bad request (400): #{response['badRequest']['message']}"
@@ -105,7 +105,7 @@ class Chef
             error_message = "Could not locate server '#{server_name}'."
             ui.error(error_message)
             raise CloudExceptions::ServerDeleteError, error_message
-          rescue Excon::Errors::BadRequest => e
+          rescue Excon::Error::BadRequest => e
             handle_excon_exception(CloudExceptions::ServerDeleteError, e)
           end
         end
@@ -119,7 +119,7 @@ class Chef
               else
                 connection.method(resource_type).call.all
               end
-            rescue Excon::Errors::BadRequest => e
+            rescue Excon::Error::BadRequest => e
               handle_excon_exception(CloudExceptions::CloudAPIException, e)
             end
           end
@@ -139,14 +139,14 @@ class Chef
         def list_resource_configurations
           begin
             connection.flavors.all
-          rescue Excon::Errors::BadRequest => e
+          rescue Excon::Error::BadRequest => e
             handle_excon_exception(CloudExceptions::CloudAPIException, e)
           end
         end
 
         def list_addresses
           connection.addresses.all
-        rescue Excon::Errors::BadRequest => e
+        rescue Excon::Error::BadRequest => e
           handle_excon_exception(CloudExceptions::CloudAPIException, e)
         end
 
@@ -160,7 +160,7 @@ class Chef
           error_message = 'Floating ip not found.'
           ui.error(error_message)
           raise CloudExceptions::NotFoundError, "#{e.message}"
-        rescue Excon::Errors::BadRequest => e
+        rescue Excon::Error::BadRequest => e
           handle_excon_exception(CloudExceptions::KnifeCloudError, e)
         end
 
@@ -170,7 +170,7 @@ class Chef
 
         def get_address(address_id)
           connection.get_address(address_id)
-        rescue Excon::Errors::BadRequest => e
+        rescue Excon::Error::BadRequest => e
           handle_excon_exception(CloudExceptions::KnifeCloudError, e)
         end
 
@@ -181,15 +181,15 @@ class Chef
           error_message = 'Floating ip pool not found.'
           ui.error(error_message)
           raise CloudExceptions::NotFoundError, "#{e.message}"
-        rescue Excon::Errors::Forbidden => e
+        rescue Excon::Error::Forbidden => e
           handle_excon_exception(CloudExceptions::KnifeCloudError, e)
-        rescue Excon::Errors::BadRequest => e
+        rescue Excon::Error::BadRequest => e
           handle_excon_exception(CloudExceptions::KnifeCloudError, e)
         end
 
         def associate_address(*args)
           connection.associate_address(*args)
-        rescue Excon::Errors::BadRequest => e
+        rescue Excon::Error::BadRequest => e
           handle_excon_exception(CloudExceptions::KnifeCloudError, e)
         end
 
@@ -198,9 +198,9 @@ class Chef
         rescue Fog::Compute::OpenStack::NotFound
           error_message = 'Floating ip not found.'
           ui.error(error_message)
-        rescue Excon::Errors::UnprocessableEntity => e
+        rescue Excon::Error::UnprocessableEntity => e
           handle_excon_exception(CloudExceptions::KnifeCloudError, e)
-        rescue Excon::Errors::BadRequest => e
+        rescue Excon::Error::BadRequest => e
           handle_excon_exception(CloudExceptions::KnifeCloudError, e)
         end
 
@@ -218,7 +218,7 @@ class Chef
 
         def get_server(instance_id)
           connection.servers.get(instance_id)
-        rescue Excon::Errors::BadRequest => e
+        rescue Excon::Error::BadRequest => e
           handle_excon_exception(CloudExceptions::KnifeCloudError, e)
         end
 

--- a/spec/unit/fog_service_spec.rb
+++ b/spec/unit/fog_service_spec.rb
@@ -52,12 +52,12 @@ describe Chef::Knife::Cloud::FogService do
       end
 
       it "handles Unauthorized exception." do
-        expect(Fog::Network).to receive(:new).with({:provider => 'Any Cloud Provider'}).and_raise Excon::Errors::Unauthorized.new("Unauthorized")
+        expect(Fog::Network).to receive(:new).with({:provider => 'Any Cloud Provider'}).and_raise Excon::Error::Unauthorized.new("Unauthorized")
         expect {instance.network}.to raise_error(Chef::Knife::Cloud::CloudExceptions::ServiceConnectionError)
       end
 
       it "handles SocketError or any other connection exception." do
-        socket_error = Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        socket_error = Excon::Error::SocketError.new(Exception.new "Mock Error")
         expect(Fog::Network).to receive(:new).with({:provider => 'Any Cloud Provider'}).and_raise socket_error
         expect {instance.network}.to raise_error(Chef::Knife::Cloud::CloudExceptions::ServiceConnectionError)
       end
@@ -99,10 +99,10 @@ describe Chef::Knife::Cloud::FogService do
         instance.method("list_#{resource_type}").call
       end
 
-      it "handles Excon::Errors::BadRequest exception." do
+      it "handles Excon::Error::BadRequest exception." do
         allow(instance).to receive(:ui).and_return(Object.new)
         allow(instance.ui).to receive(:fatal)
-        allow(instance).to receive_message_chain(resource.to_sym, "#{resource_type}".to_sym, :all).and_raise Excon::Errors::BadRequest.new("Invalid Resource")
+        allow(instance).to receive_message_chain(resource.to_sym, "#{resource_type}".to_sym, :all).and_raise Excon::Error::BadRequest.new("Invalid Resource")
         expect {instance.method("list_#{resource_type}").call}.to raise_error(Chef::Knife::Cloud::CloudExceptions::CloudAPIException)
       end
     end

--- a/spec/unit/list_resource_command_spec.rb
+++ b/spec/unit/list_resource_command_spec.rb
@@ -20,7 +20,7 @@
 require 'spec_helper'
 require 'chef/knife/cloud/list_resource_command'
 require 'support/shared_examples_for_command'
-require 'excon/errors'
+require 'excon/error'
 
 describe Chef::Knife::Cloud::ResourceListCommand do
   it_behaves_like Chef::Knife::Cloud::Command, Chef::Knife::Cloud::ResourceListCommand.new
@@ -52,9 +52,9 @@ describe Chef::Knife::Cloud::ResourceListCommand do
         expect {instance.list(test_resource)}.to raise_error(StandardError)
       end
 
-      it "handle Excon::Errors::BadRequest exception." do
-        allow(test_resource).to receive(:sort_by).and_raise Excon::Errors::BadRequest.new("excon error message")
-        expect {instance.list(test_resource)}.to raise_error(Excon::Errors::BadRequest)
+      it "handle Excon::Error::BadRequest exception." do
+        allow(test_resource).to receive(:sort_by).and_raise Excon::Error::BadRequest.new("excon error message")
+        expect {instance.list(test_resource)}.to raise_error(Excon::Error::BadRequest)
       end
     end
   end

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -31,11 +31,11 @@ describe Chef::Knife::Cloud::Service do
 
  it { expect {instance.delete_server(:server_name)}.to raise_error(Chef::Exceptions::Override, "You must override delete_server in #{instance.to_s}") }
 
- it { expect {instance.delete_server}.to raise_error(ArgumentError, "wrong number of arguments (given 0, expected 1)") }
+ it { expect {instance.delete_server}.to raise_error(ArgumentError) }
 
  it { expect {instance.list_servers}.to raise_error(Chef::Exceptions::Override, "You must override list_servers in #{instance.to_s}") }
 
- it { expect {instance.list_images}.to raise_error(ArgumentError, "wrong number of arguments (given 0, expected 1)") }
+ it { expect {instance.list_images}.to raise_error(ArgumentError) }
 
  it { expect {instance.list_images(:image_filters)}.to raise_error(Chef::Exceptions::Override, "You must override list_images in #{instance.to_s}") }
 

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -31,11 +31,11 @@ describe Chef::Knife::Cloud::Service do
 
  it { expect {instance.delete_server(:server_name)}.to raise_error(Chef::Exceptions::Override, "You must override delete_server in #{instance.to_s}") }
 
- it { expect {instance.delete_server}.to raise_error(ArgumentError, "wrong number of arguments (0 for 1)") }
+ it { expect {instance.delete_server}.to raise_error(ArgumentError, "wrong number of arguments (given 0, expected 1)") }
 
  it { expect {instance.list_servers}.to raise_error(Chef::Exceptions::Override, "You must override list_servers in #{instance.to_s}") }
 
- it { expect {instance.list_images}.to raise_error(ArgumentError, "wrong number of arguments (0 for 1)") }
+ it { expect {instance.list_images}.to raise_error(ArgumentError, "wrong number of arguments (given 0, expected 1)") }
 
  it { expect {instance.list_images(:image_filters)}.to raise_error(Chef::Exceptions::Override, "You must override list_images in #{instance.to_s}") }
 


### PR DESCRIPTION
Remove support for Chef 10/11
Require reasonable knife-windows release
Require chefstyle not rubocop

Signed-off-by: Tim Smith <tsmith@chef.io>