### PR TITLE
Rescue the right Excon Socket error

### DIFF
--- a/lib/chef/knife/cloud/fog/service.rb
+++ b/lib/chef/knife/cloud/fog/service.rb
@@ -35,7 +35,7 @@ class Chef
                             error_message = "Connection failure, please check your username and password."
                             ui.fatal(error_message)
                             raise CloudExceptions::ServiceConnectionError, "#{e.message}. #{error_message}"
-                          rescue Excon::Error::SocketError => e
+                          rescue Excon::Error::Socket => e
                             error_message = "Connection failure, please check your authentication URL."
                             ui.fatal(error_message)
                             raise CloudExceptions::ServiceConnectionError, "#{e.message}. #{error_message}"
@@ -49,7 +49,7 @@ class Chef
                         error_message = "Connection failure, please check your username and password."
                         ui.fatal(error_message)
                         raise CloudExceptions::ServiceConnectionError, "#{e.message}. #{error_message}"
-                      rescue Excon::Error::SocketError => e
+                      rescue Excon::Error::Socket => e
                         error_message = "Connection failure, please check your authentication URL."
                         ui.fatal(error_message)
                         raise CloudExceptions::ServiceConnectionError, "#{e.message}. #{error_message}"

--- a/spec/unit/fog_service_spec.rb
+++ b/spec/unit/fog_service_spec.rb
@@ -57,7 +57,7 @@ describe Chef::Knife::Cloud::FogService do
       end
 
       it "handles SocketError or any other connection exception." do
-        socket_error = Excon::Error::SocketError.new(Exception.new "Mock Error")
+        socket_error = Excon::Error::Socket.new(Exception.new "Mock Error")
         expect(Fog::Network).to receive(:new).with({ :provider => "Any Cloud Provider" }).and_raise socket_error
         expect { instance.network }.to raise_error(Chef::Knife::Cloud::CloudExceptions::ServiceConnectionError)
       end


### PR DESCRIPTION
It's Excon::Error::Socket not Excon::Error::SocketError. The spec fails on Ruby 2.5, but it's not doing what we think it is on any version of Ruby.

https://github.com/excon/excon/blob/master/lib/excon/error.rb#L12

Signed-off-by: Tim Smith <tsmith@chef.io>