### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/cloud/chefbootstrap/bootstrap_distribution.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/bootstrap_distribution.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "chef/knife/cloud/helpers"
+require_relative "../helpers"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/chefbootstrap/bootstrap_protocol.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/bootstrap_protocol.rb
@@ -18,7 +18,7 @@
 #
 
 require "chef/knife/core/ui"
-require "chef/knife/cloud/helpers"
+require_relative "../helpers"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/chefbootstrap/bootstrapper.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/bootstrapper.rb
@@ -18,10 +18,10 @@
 #
 
 require "chef/knife/core/ui"
-require "chef/knife/cloud/chefbootstrap/ssh_bootstrap_protocol"
-require "chef/knife/cloud/chefbootstrap/winrm_bootstrap_protocol"
-require "chef/knife/cloud/chefbootstrap/bootstrap_distribution"
-require "chef/knife/cloud/exceptions"
+require_relative "ssh_bootstrap_protocol"
+require_relative "winrm_bootstrap_protocol"
+require_relative "bootstrap_distribution"
+require_relative "../exceptions"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/chefbootstrap/ssh_bootstrap_protocol.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/ssh_bootstrap_protocol.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/chefbootstrap/bootstrap_protocol"
+require_relative "bootstrap_protocol"
 require "chef/knife/core/windows_bootstrap_context"
 require "chef/knife/bootstrap"
 

--- a/lib/chef/knife/cloud/chefbootstrap/winrm_bootstrap_protocol.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/winrm_bootstrap_protocol.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/chefbootstrap/bootstrap_protocol"
+require_relative "bootstrap_protocol"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/command.rb
+++ b/lib/chef/knife/cloud/command.rb
@@ -17,8 +17,8 @@
 #
 
 require "chef/knife"
-require "chef/knife/cloud/helpers"
-require "chef/knife/cloud/exceptions"
+require_relative "helpers"
+require_relative "exceptions"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/command_bootstrap.rb
+++ b/lib/chef/knife/cloud/command_bootstrap.rb
@@ -17,8 +17,8 @@
 #
 
 require "chef/knife/bootstrap"
-require "chef/knife/cloud/helpers"
-require "chef/knife/cloud/exceptions"
+require_relative "helpers"
+require_relative "exceptions"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/fog/service.rb
+++ b/lib/chef/knife/cloud/fog/service.rb
@@ -4,8 +4,8 @@
 # Copyright:: Copyright (c) 2013-2016 Chef Software, Inc.
 #
 
-require "chef/knife/cloud/service"
-require "chef/knife/cloud/exceptions"
+require_relative "../service"
+require_relative "../exceptions"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/list_resource_command.rb
+++ b/lib/chef/knife/cloud/list_resource_command.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/command"
+require_relative "command"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/server/create_command.rb
+++ b/lib/chef/knife/cloud/server/create_command.rb
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/knife/cloud/command_bootstrap"
-require "chef/knife/cloud/exceptions"
-require "chef/knife/cloud/chefbootstrap/bootstrapper"
+require_relative "../command_bootstrap"
+require_relative "../exceptions"
+require_relative "../chefbootstrap/bootstrapper"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/server/create_options.rb
+++ b/lib/chef/knife/cloud/server/create_options.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/chefbootstrap/bootstrap_options"
-require "chef/knife/cloud/server/options"
+require_relative "../chefbootstrap/bootstrap_options"
+require_relative "options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/server/delete_command.rb
+++ b/lib/chef/knife/cloud/server/delete_command.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/command"
+require_relative "../command"
 # These two are needed for the '--purge' deletion case
 require "chef/node"
 require "chef/api_client"

--- a/lib/chef/knife/cloud/server/delete_options.rb
+++ b/lib/chef/knife/cloud/server/delete_options.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/server/options"
+require_relative "options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/server/list_command.rb
+++ b/lib/chef/knife/cloud/server/list_command.rb
@@ -1,5 +1,5 @@
-require "chef/knife/cloud/list_resource_command"
-require "chef/knife/cloud/exceptions"
+require_relative "../list_resource_command"
+require_relative "../exceptions"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/server/show_command.rb
+++ b/lib/chef/knife/cloud/server/show_command.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/command"
-require "chef/knife/cloud/exceptions"
+require_relative "../command"
+require_relative "../exceptions"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/service.rb
+++ b/lib/chef/knife/cloud/service.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/exceptions"
-require "chef/knife/cloud/helpers"
+require_relative "exceptions"
+require_relative "helpers"
 
 class Chef
   class Knife


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>