### PR TITLE
Switch to fog-core for load_fog_gem function from fog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem "rspec-expectations"
   gem "rspec-mocks"
   gem "rspec_junit_formatter"
-  gem "fog"
+  gem "fog-core"
   gem "chefstyle"
   gem "chef", ">= 15.0"
 end

--- a/lib/chef/knife/cloud/fog/service.rb
+++ b/lib/chef/knife/cloud/fog/service.rb
@@ -18,12 +18,12 @@ class Chef
         end
 
         def load_fog_gem
-            # Load specific version of fog. Any other classes/modules using fog are loaded after this.
-          gem "fog", Chef::Config[:knife][:cloud_fog_version]
-          require "fog"
-          Chef::Log.debug("Using fog version: #{Gem.loaded_specs["fog"].version}")
+          # Load specific version of fog-core. Any other classes/modules using fog-core are loaded after this.
+          gem "fog-core", Chef::Config[:knife][:cloud_fog_version]
+          require "fog/core"
+          Chef::Log.debug("Using fog-core version: #{Gem.loaded_specs["fog-core"].version}")
         rescue Exception
-          Chef::Log.error "Error loading fog gem."
+          Chef::Log.error "Error loading fog-core gem."
           exit 1
         end
 


### PR DESCRIPTION
The 'fog' gem pulls in all the various providers which is not needed for simple
functionality. Instead we should be pulling in the 'fog-core' gem which has what
we need for this gem.

This simplifies how dependencies work on other knife plugins which use
knife-cloud (such as knife-openstack).

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG