### PR TITLE
Fixes SSH gateway remote SSH port option handling

### DIFF
--- a/lib/chef/knife/cloud/chefbootstrap/ssh_bootstrap_protocol.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/ssh_bootstrap_protocol.rb
@@ -130,7 +130,8 @@ class Chef
         def tunnel_test_ssh(ssh_gateway, hostname, &block)
           status = false
           gateway = configure_ssh_gateway(ssh_gateway)
-          gateway.open(hostname, config[:ssh_port]) do |local_tunnel_port|
+          remote_ssh_port = config[:connection_port] || config[:ssh_port] || 22
+          gateway.open(hostname, remote_ssh_port) do |local_tunnel_port|
             status = tcp_test_ssh("localhost", local_tunnel_port, &block)
           end
           status

--- a/lib/chef/knife/cloud/chefbootstrap/ssh_bootstrap_protocol.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/ssh_bootstrap_protocol.rb
@@ -32,12 +32,12 @@ class Chef
         end
 
         def init_bootstrap_options
-          bootstrap.config[:connection_user] = @config[:connection_user]
-          bootstrap.config[:connection_password] = @config[:connection_password]
+          bootstrap.config[:connection_user] = config[:connection_user]
+          bootstrap.config[:connection_password] = config[:connection_password]
           bootstrap.config[:connection_port] = config[:connection_port]
-          bootstrap.config[:ssh_identity_file] = @config[:ssh_identity_file]
-          bootstrap.config[:ssh_verify_host_key] = @config[:ssh_verify_host_key]
-          bootstrap.config[:use_sudo] = true unless @config[:connection_user] == "root"
+          bootstrap.config[:ssh_identity_file] = config[:ssh_identity_file]
+          bootstrap.config[:ssh_verify_host_key] = config[:ssh_verify_host_key]
+          bootstrap.config[:use_sudo] = true unless config[:connection_user] == "root"
           bootstrap.config[:ssh_gateway] = config[:ssh_gateway]
           bootstrap.config[:forward_agent] = config[:forward_agent]
           bootstrap.config[:use_sudo_password] = config[:use_sudo_password]
@@ -45,19 +45,19 @@ class Chef
         end
 
         def wait_for_server_ready
-          print "\n#{ui.color("Waiting for sshd to host (#{@config[:bootstrap_ip_address]})", :magenta)}"
+          print "\n#{ui.color("Waiting for sshd to host (#{config[:bootstrap_ip_address]})", :magenta)}"
 
-          ssh_gateway = get_ssh_gateway_for(@config[:bootstrap_ip_address])
+          ssh_gateway = get_ssh_gateway_for(config[:bootstrap_ip_address])
 
           # The ssh_gateway & subnet_id are currently supported only in EC2.
           if ssh_gateway
-            print(".") until tunnel_test_ssh(ssh_gateway, @config[:bootstrap_ip_address]) do
+            print(".") until tunnel_test_ssh(ssh_gateway, config[:bootstrap_ip_address]) do
               @initial_sleep_delay = !!config[:subnet_id] ? 40 : 10
               sleep @initial_sleep_delay
               puts("done")
             end
           else
-            print(".") until tcp_test_ssh(@config[:bootstrap_ip_address], config[:connection_port] || config[:ssh_port] ) do
+            print(".") until tcp_test_ssh(config[:bootstrap_ip_address], config[:connection_port] || config[:ssh_port] ) do
               @initial_sleep_delay = !!config[:subnet_id] ? 40 : 10
               sleep @initial_sleep_delay
               puts("done")


### PR DESCRIPTION
## Description
I recently discovered that knife-cloud was incorrectly handling options for specifying the remote SSH port of the node you want to bootstrap when using an SSH gateway. The problem was that it was only honoring the deprecated `--ssh-port` option and not the replacement option `--connection-port`. It also lacked a default of port 22, so when `--ssh-port` was unspecified, `nil` was being passed as the remote port for the SSH gateway. From my cursory reading of [RFC 4254](https://tools.ietf.org/html/rfc4254#section-7.2) not passing a remote port is unspecified behavior so I've added a default for the remote port.

## Related Issue
https://github.com/chef/knife-cloud/issues/134

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Can you please clarify the difference between the pre-merge tests and all new and existing tests? I have passing tests per `rake spec && rake style`.
I didn't see any relevant documentation to update, but if I've missed something please let me know and I'll address it.
