### PR TITLE
Remove redundant encoding comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,5 @@ group :test do
   gem "rspec-mocks"
   gem "rspec_junit_formatter"
   gem "fog-core"
-  gem "chefstyle"
+  gem "chefstyle", "1.2.0"
 end

--- a/knife-cloud.gemspec
+++ b/knife-cloud.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 require "knife-cloud/version"
 


### PR DESCRIPTION
There's no need for these in Ruby 2.0+

Signed-off-by: Tim Smith <tsmith@chef.io>