### PR TITLE
move ssh/multi require into deps do

### DIFF
--- a/lib/chef/knife/cloud/chefbootstrap/bootstrap_options.rb
+++ b/lib/chef/knife/cloud/chefbootstrap/bootstrap_options.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 require "chef/knife/core/bootstrap_context"
-require "net/ssh/multi"
 
 class Chef
   class Knife
@@ -32,6 +31,7 @@ class Chef
               require "chef/json_compat"
               require "tempfile" unless defined?(Tempfile)
               require "net/ssh" unless defined?(Net::SSH)
+              require "net/ssh/multi"
               require "chef/knife/ssh"
               Chef::Knife::Ssh.load_deps
             end


### PR DESCRIPTION
This removes about 1 second from loading the knife command. It is unclear to me where ssh/multi is used in this gem because I do not see any usage of `Net::SSH::Multi.start`. Perhaps it is required here for the benefit of consumers??

Signed-off-by: mwrock <matt@mattwrock.com>
