### PR TITLE
CHEF-1921 Fixed the knife-cloud verify test failure

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -16,7 +16,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.1-buster
+        image: ruby:3.1
 - label: run-specs-windows
   command:
     - bundle config --local path vendor/bundle

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -27,3 +27,4 @@ steps:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:3.1

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -27,4 +27,3 @@ steps:
     executor:
       docker:
         host_os: windows
-        image: rubydistros/windows-2019:3.1

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,20 +10,13 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-specs-ruby-2.6
+- label: run-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-buster
-- label: run-specs-ruby-2.7
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7-buster
+        image: ruby:3.1-buster
 - label: run-specs-windows
   command:
     - bundle config --local path vendor/bundle
@@ -34,3 +27,4 @@ steps:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:3.1

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :test do
     gem "chef", "~> 15"
   else
     gem "chef", ">= 18.0"
+    gem "knife"
   end
   gem "rspec-expectations"
   gem "rspec-mocks"

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
     gem "chef-zero", "~> 15"
     gem "chef", "~> 15"
   else
-    gem "chef", ">= 16.0"
+    gem "chef", ">= 18.0"
   end
   gem "rspec-expectations"
   gem "rspec-mocks"

--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,5 @@ group :test do
   gem "rspec-mocks"
   gem "rspec_junit_formatter"
   gem "fog-core"
-  gem "chefstyle", "2.1.1"
+  gem "chefstyle", "2.2.2"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,14 @@ end
 
 group :test do
   gem "rake"
-  gem "rspec-core"
+  gem "rspec-core", '~> 3.9'
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
     gem "chef-zero", "~> 15"
     gem "chef", "~> 15"
+  elsif Gem::Version.new(RUBY_VERSION) > Gem::Version.new("3.1")
+    gem "chef-zero", "~> 15"
+    gem "chef", "~> 18"
+    gem "knife"
   else
     gem "chef", ">= 18.0"
     gem "knife"

--- a/Gemfile
+++ b/Gemfile
@@ -15,12 +15,13 @@ group :test do
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
     gem "chef-zero", "~> 15"
     gem "chef", "~> 15"
-  elsif Gem::Version.new(RUBY_VERSION) > Gem::Version.new("3.1")
+  elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.1")
     gem "chef-zero", "~> 15"
-    gem "chef", "~> 18"
+    gem "chef", ">= 17.0"
     gem "knife"
   else
-    gem "chef", ">= 18.0"
+    gem "chef-zero", "~> 15"
+    gem "chef", "~> 18"
     gem "knife"
   end
   gem "rspec-expectations"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 group :test do
   gem "rake"
-  gem "rspec-core", '~> 3.9'
+  gem "rspec-core", "~> 3.9"
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
     gem "chef-zero", "~> 15"
     gem "chef", "~> 15"

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test do
     gem "knife"
   end
   gem "rspec-expectations"
-  gem "rspec-mocks"
+  gem "rspec-mocks", "3.9.0"
   gem "rspec_junit_formatter"
   gem "fog-core"
   gem "chefstyle", "2.2.2"

--- a/knife-cloud.gemspec
+++ b/knife-cloud.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = %w{lib}
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 3.1"
 
-  s.add_dependency "chef", ">= 15.11"
+  s.add_dependency "chef", ">= 18.0"
   s.add_dependency "mixlib-shellout"
   s.add_dependency "excon", ">=  0.50" # excon 0.50 renamed the errors class and required updating rescues
 end

--- a/lib/chef/knife/cloud/fog/service.rb
+++ b/lib/chef/knife/cloud/fog/service.rb
@@ -108,16 +108,16 @@ class Chef
 
         %w{servers images networks}.each do |resource_type|
           define_method("list_#{resource_type}") do
-            begin
-              case resource_type
-              when "networks"
-                network.method(resource_type).call.all
-              else
-                connection.method(resource_type).call.all
-              end
-            rescue Excon::Error::BadRequest => e
-              handle_excon_exception(CloudExceptions::CloudAPIException, e)
+
+            case resource_type
+            when "networks"
+              network.method(resource_type).call.all
+            else
+              connection.method(resource_type).call.all
             end
+          rescue Excon::Error::BadRequest => e
+            handle_excon_exception(CloudExceptions::CloudAPIException, e)
+
           end
         end
 


### PR DESCRIPTION

## Description
updated ruby version to 3.1 and removed 2.7 and 3.0 ruby verify pipeline as the latest chef 18.2.7 supports ruby >= 3.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
