### PR TITLE
Fix Ruby 3.1 winrm test failures

### DIFF
--- a/spec/unit/bootstrapper_spec.rb
+++ b/spec/unit/bootstrapper_spec.rb
@@ -49,6 +49,7 @@ describe Chef::Knife::Cloud::Bootstrapper do
     end
 
     it "executes with correct method calls with winrm" do
+      allow_any_instance_of(Chef::Knife::Cloud::WinrmBootstrapProtocol).to receive(:load_winrm_deps)
       winrm_bootstrap_protocol = Chef::Knife::Cloud::WinrmBootstrapProtocol.new(@config)
       allow(@instance).to receive(:create_bootstrap_protocol).and_return(winrm_bootstrap_protocol)
       expect(@instance).to receive(:create_bootstrap_protocol).ordered
@@ -118,6 +119,7 @@ describe Chef::Knife::Cloud::Bootstrapper do
     context "when connection_protocol set to winrm" do
       before(:each) do
         @config[:connection_protocol] = "winrm"
+        allow_any_instance_of(Chef::Knife::Cloud::WinrmBootstrapProtocol).to receive(:load_winrm_deps)
       end
 
       it "instantiates WinrmBootstrapProtocol class." do

--- a/spec/unit/winrm_bootstrap_protocol_spec.rb
+++ b/spec/unit/winrm_bootstrap_protocol_spec.rb
@@ -20,6 +20,7 @@ require "chef/knife/cloud/chefbootstrap/winrm_bootstrap_protocol"
 
 describe Chef::Knife::Cloud::WinrmBootstrapProtocol do
   before do
+    allow_any_instance_of(Chef::Knife::Cloud::WinrmBootstrapProtocol).to receive(:load_winrm_deps)
     @config = { connection_protocol: "winrm" }
     @config = { image_os_type: "windows" }
     @instance = Chef::Knife::Cloud::WinrmBootstrapProtocol.new(@config)


### PR DESCRIPTION
Stub `load_winrm_deps` method before creating `WinrmBootstrapProtocol` instances in tests.

The `winrm` gem is an optional runtime dependency (not in gemspec). When tests create `WinrmBootstrapProtocol` objects, the `initialize` method calls `load_winrm_deps` which tries to `require 'winrm'`, causing `LoadError` in test environments without the gem installed.

